### PR TITLE
semver_clean buffer overflow fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Helper to free allocated memory from heap.
 
 Checks if the given string is a valid semver expression.
 
-#### semver_clean(const char *str, char *dest) => int
+#### semver_clean(char *str) => int
 
 Removes invalid semver characters in a given string.
 

--- a/semver.c
+++ b/semver.c
@@ -650,17 +650,16 @@ semver_is_valid (const char *s) {
  */
 
 int
-semver_clean (const char *s, char *dest) {
+semver_clean (char *s) {
   if (has_valid_length(s) == 0) return -1;
 
   int offset = 0;
-  strcpy((char *) dest, s);
   size_t len = strlen(s);
   size_t mlen = strlen(VALID_CHARS);
 
   for (unsigned int i = 0; i < len; i++) {
     if (contains(s[i], VALID_CHARS, mlen) == 0) {
-      strcut((char *) dest, i - offset, 1);
+      strcut(s, i - offset, 1);
       offset++;
     }
   }

--- a/semver.c
+++ b/semver.c
@@ -653,14 +653,13 @@ int
 semver_clean (char *s) {
   if (has_valid_length(s) == 0) return -1;
 
-  int offset = 0;
   size_t len = strlen(s);
   size_t mlen = strlen(VALID_CHARS);
 
   for (unsigned int i = 0; i < len; i++) {
     if (contains(s[i], VALID_CHARS, mlen) == 0) {
-      strcut(s, i - offset, 1);
-      offset++;
+      strcut(s, i, 1);
+      --len; --i;
     }
   }
 

--- a/semver.c
+++ b/semver.c
@@ -45,7 +45,7 @@ strcut (char *str, int begin, int len) {
 
   if (len < 0) len = l - begin;
   if (begin + len > l) len = l - begin;
-  memmove(str + begin, str + begin + len, l - len + 1);
+  memmove(str + begin, str + begin + len, l - len + 1 - begin);
 
   return len;
 }

--- a/semver.h
+++ b/semver.h
@@ -105,7 +105,7 @@ int
 semver_is_valid (const char *s);
 
 int
-semver_clean (const char *s, char *dest);
+semver_clean (char *s);
 
 #ifdef __cplusplus
 }

--- a/semver_test.c
+++ b/semver_test.c
@@ -638,16 +638,14 @@ test_clean() {
 
   int error;
 
-  char * str = "1.2.3";
-  char * dest[10];
-  error = semver_clean(str, (char *) dest);
-  assert(strcmp((char *) dest, "1.2.3") == 0);
+  char str[] = "1.2.3";
+  error = semver_clean(str);
+  assert(strcmp(str, "1.2.3") == 0);
   assert(error == 0);
 
-  char * str2 = " 1.@2.3-beta #.alpha+12@34  ";
-  char * dest2[15];
-  error = semver_clean(str2, (char *) dest2);
-  assert(strcmp((char *) dest2, "1.2.3-beta.alpha+1234") == 0);
+  char str2[] = " 1.@2.3-beta #.alpha+12@34  ";
+  error = semver_clean(str2);
+  assert(strcmp(str2, "1.2.3-beta.alpha+1234") == 0);
   assert(error == 0);
 
   test_end();


### PR DESCRIPTION
This is a partial solution to #12, which fixes `semver_clean` (though not `semver_render`) by operating on the string in-place.

This also uncovered an issue with `strcut`, which would move memory from past the end of the buffer, sometimes resulting in a crash.