### PR TITLE
add '.x' partial version support

### DIFF
--- a/semver.h
+++ b/semver.h
@@ -24,6 +24,9 @@ typedef struct semver_version_s {
   int major;
   int minor;
   int patch;
+  int is_major_set;
+  int is_minor_set;
+  int is_patch_set;
   char * metadata;
   char * prerelease;
 } semver_t;
@@ -70,6 +73,9 @@ semver_neq (semver_t x, semver_t y);
 
 int
 semver_parse (const char *str, semver_t *ver);
+
+int
+semver_parse_op(const char *str, semver_t *ver, char (*op)[3]);
 
 int
 semver_parse_version (const char *str, semver_t *ver);


### PR DESCRIPTION
From my own needs...

*Maybe an idea form improvement ?*

I actually realize that `semver_satisfies` didn't support those kind of situation *(with no "operation")*:
- "1.2.3" should statisfy "1.2.x"
- "1.2.3" should statisfy "1.2"

To achieved that, I also add a little helper "`semver_parse_op`" to retrieve "operation" from a string

Example
```c
semver_t semver = {};
char op[3];
semver_parse_op(">=1.2.x", &semver, &op)

/*
returns

 op: ">="

 semver: {
   major = 1
   minor = 2
   patch = 0
   is_major_set = 1
   is_minor_set = 1
   is_patch_set = 0
}
*/
```
 

